### PR TITLE
Prevent exception on invalid class name reflection during denormalization

### DIFF
--- a/sources/lib/Serializer/Normalizer/FlexibleEntityDenormalizer.php
+++ b/sources/lib/Serializer/Normalizer/FlexibleEntityDenormalizer.php
@@ -10,6 +10,7 @@
 namespace PommProject\SymfonyBridge\Serializer\Normalizer;
 
 use PommProject\Foundation\Pomm;
+use PommProject\ModelManager\Model\FlexibleEntity\FlexibleEntityInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 /**
@@ -53,7 +54,7 @@ class FlexibleEntityDenormalizer implements DenormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization(mixed $data, string $type, $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
     {
         if (!class_exists($type)) {
             return false;
@@ -62,7 +63,6 @@ class FlexibleEntityDenormalizer implements DenormalizerInterface
         $reflection = new \ReflectionClass($type);
         $interfaces = $reflection->getInterfaces();
 
-        // @TODO Use FlexibleEntityInterface::class with php >= 5.5
-        return isset($interfaces['PommProject\ModelManager\Model\FlexibleEntity\FlexibleEntityInterface']);
+        return isset($interfaces[FlexibleEntityInterface::class]);
     }
 }

--- a/sources/lib/Serializer/Normalizer/FlexibleEntityDenormalizer.php
+++ b/sources/lib/Serializer/Normalizer/FlexibleEntityDenormalizer.php
@@ -55,6 +55,10 @@ class FlexibleEntityDenormalizer implements DenormalizerInterface
      */
     public function supportsDenormalization(mixed $data, string $type, $format = null): bool
     {
+        if (!class_exists($type)) {
+            return false;
+        }
+
         $reflection = new \ReflectionClass($type);
         $interfaces = $reflection->getInterfaces();
 


### PR DESCRIPTION
- Prevent exception on invalid class name reflection during denormalization
- minor changes, since PHP < 8.1 is no longer supported (argument type hint, todo `::class`)